### PR TITLE
Stage8 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ They are dependent on [Kaldi](https://github.com/kaldi-asr/kaldi) and the
 unreleased Ruv-di dataset. These scripts assume there are speaker ids within
 the Ruv-di dataset.
 
+**NOTE!** We use code for the expansion that is not in the official Kaldi version. 
+**TO DO:** Extract those files from our Kaldi src dir and ship with this recipe
 
 ## Running
 1. To run the scripts, clone this directory in the Kaldi egs folder or just

--- a/run.sh
+++ b/run.sh
@@ -68,18 +68,27 @@ fi
 
 if [ $stage -le 2 ]; then
     echo 'Create the files necessary for Kaldi'
-    echo 'Create segment and text files out of vtt subtitle files'
+    echo 'Create text files out of vtt subtitle files'
     for file in "$datadir"/vtt/*.vtt; do
         name=$(basename "$file")
-        python3 local/create_segments_and_text.py \
+        python3 local/extract_text.py \
         "$file" "$datadir"/transcripts/"${name%.*}"
     done
     
     echo 'Create wav.scp'
     for path in "$datadir"/transcripts/*; do
         name=$(basename "$path")
-        echo -e 'unknown-'"${name}"' sox -twav - -c1 -esigned -r16000 -G -twav - < '"$corpusdir/wav/${name}".wav' |' >> "$datadir"/wav.scp
+        echo -e "${name}"' sox -twav - -c1 -esigned -r16000 -G -twav - < '"$corpusdir/wav/${name}".wav' |' >> "$datadir"/wav.scp
     done
+    
+    echo "Create a segments file"
+    while IFS= read -r line
+    do
+        name=$(basename "$line")
+        dur=$(soxi -D "$line")
+        number=$(LC_NUMERIC="en_US.UTF-8" printf "%.7g" "$dur")
+        echo -e unknown-"${name%.*}" "${name%.*}" 0 "$number" >> "$datadir"/segments
+    done < <(cut -d' ' -f12 "$datadir"/wav.scp)
     
     echo 'Create utt2spk'
     for path in "$datadir"/transcripts/*; do
@@ -114,6 +123,8 @@ if [ $stage -le 4 ]; then
     # NOTE! Fix the uttIDs
     sed -i -r 's/^(unknown) ([0-9]+) ([a-z]) ([0-9])/\1-\2\u\3\4/' "$datadir"/text_cleaned
     
+    # NOTE! We use code for the expansion that is not in the official Kaldi version.
+    # TO DO: Extract those files from our Kaldi src dir and ship with this recipe
     echo 'Expand abbreviations and numbers'
     utils/slurm.pl --mem 4G "$datadir"/log/expand_text.log \
     local/expand_text.sh "$datadir"/text_cleaned "$datadir"/text_expanded
@@ -268,7 +279,6 @@ if [ $stage -le 11 ]; then
     
     # Copy wav.scp over
     cp "${datadir}"_reseg/wav.scp "${datadir}"_final/wav.scp
-    sed -i 's/unknown-//' "${datadir}"_final/wav.scp
     
     echo 'Create spk2utt'
     utils/utt2spk_to_spk2utt.pl < "$datadir"_final/utt2spk > "$datadir"_final/spk2utt


### PR DESCRIPTION
This is based on the previous pull requests for stages 3-7.  #5 #6 

Within switch_to_true_spkID cast diar_row[0] to int so it's the same type as meta_row[1]
Make the ruvdi variable directory
specify python3

In stage 11, grep exits on no-zero but we want that set unset exit on errors and then reset directly after the while loop
Remove unknown from wav.scp in asr_ruvdi_final to match naming conventions